### PR TITLE
Validate encoded hashes and extract the salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ password.is_password?("opensesame")    #=> true
 password.is_password?("notopensesame") #=> false
 ```
 
+The original salt for a password can be retrieved with `Argon2id::Password#salt`:
+
+```ruby
+password = Argon2id::Password.new("$argon2id$v=19$m=256,t=2,p=1$c29tZXNhbHQ$nf65EOgLrQMR/uIPnA4rEsF5h7TKyQwu9U1bMCHGi/4")
+password.salt
+#=> "somesalt"
+```
+
 ### Errors
 
 Any errors returned from Argon2 will be raised as `Argon2id::Error`, e.g.

--- a/argon2id.gemspec
+++ b/argon2id.gemspec
@@ -53,6 +53,7 @@ Gem::Specification.new do |s|
   ]
   s.rdoc_options = ["--main", "README.md"]
 
+  s.add_runtime_dependency("base64")
   s.add_development_dependency("rake-compiler", "~> 1.2")
   s.add_development_dependency("rake-compiler-dock", "~> 1.5")
   s.add_development_dependency("minitest", "~> 5.25")

--- a/lib/argon2id.rb
+++ b/lib/argon2id.rb
@@ -15,7 +15,7 @@ module Argon2id
   DEFAULT_T_COST = 2
 
   # The default "memory cost" of 19 mebibytes recommended by OWASP.
-  DEFAULT_M_COST = 19456
+  DEFAULT_M_COST = 19_456
 
   # The default 1 thread and compute lane recommended by OWASP.
   DEFAULT_PARALLELISM = 1

--- a/test/test_password.rb
+++ b/test/test_password.rb
@@ -74,13 +74,33 @@ class TestPassword < Minitest::Test
     refute password.is_password?("notopensesame")
   end
 
-  def test_raises_if_verifying_with_invalid_encoded_password
-    password = Argon2id::Password.new("invalid")
+  def test_salt_returns_the_original_salt
+    password = Argon2id::Password.new("$argon2id$v=19$m=256,t=2,p=1$c29tZXNhbHQ$nf65EOgLrQMR/uIPnA4rEsF5h7TKyQwu9U1bMCHGi/4")
 
-    error = assert_raises(Argon2id::Error) do
-      password.is_password?("opensesame")
+    assert_equal "somesalt", password.salt
+  end
+
+  def test_salt_returns_raw_bytes
+    password = Argon2id::Password.new("$argon2id$v=19$m=256,t=2,p=1$KmIxrXv4lrnSJPO0LN7Gdw$lB3724qLPL9MNi10lkvIb4VxIk3q841CLvq0WTCZ0VQ")
+
+    assert_equal "*b1\xAD{\xF8\x96\xB9\xD2$\xF3\xB4,\xDE\xC6w".b, password.salt
+  end
+
+  def test_raises_for_invalid_hashes
+    assert_raises(ArgumentError) do
+      Argon2id::Password.new("not a valid hash")
     end
+  end
 
-    assert_equal "Decoding failed", error.message
+  def test_raises_for_partial_hashes
+    assert_raises(ArgumentError) do
+      Argon2id::Password.new("$argon2id$v=19$m=256,t=2,p=1$KmIxrXv4lrnSJPO0LN7Gdw")
+    end
+  end
+
+  def test_salt_supports_versionless_hashes
+    password = Argon2id::Password.new("$argon2id$m=256,t=2,p=1$c29tZXNhbHQ$nf65EOgLrQMR/uIPnA4rEsF5h7TKyQwu9U1bMCHGi/4")
+
+    assert_equal "somesalt", password.salt
   end
 end


### PR DESCRIPTION
So we can provide a salt reader on an Argon2id::Password instance, parse the encoded salt when passing it to Argon2id::Password.new, rejecting anything that doesn't match the expected pattern and decoding the salt in the process.

Note we have to add base64 as a runtime dependency as it is one of Ruby's default gems but will become "bundled" in 3.4, see https://stdgems.org/base64/
