### PR TITLE
Add JRuby support via JRuby-OpenSSL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,17 @@ jobs:
           name: cruby-gem
           path: pkg/*.gem
 
+  test-jruby:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "jruby-9.4"
+          bundler-cache: true
+      - run: bundle exec rake test
+
+
   precompile-aarch64-linux:
     uses: ./.github/workflows/precompile-gem.yml
     with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,17 +31,6 @@ jobs:
           name: cruby-gem
           path: pkg/*.gem
 
-  test-jruby:
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "jruby-9.4"
-          bundler-cache: true
-      - run: bundle exec rake test
-
-
   precompile-aarch64-linux:
     uses: ./.github/workflows/precompile-gem.yml
     with:
@@ -86,6 +75,11 @@ jobs:
     uses: ./.github/workflows/precompile-gem.yml
     with:
       platform: x86-mingw32
+
+  precompile-jruby:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: jruby
 
   test-ubuntu:
     needs: "build-cruby-gem"
@@ -315,6 +309,23 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-darwin-gem
+          path: pkg
+      - run: ./scripts/test-gem-install
+        env:
+          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
+
+  test-precompiled-jruby:
+    needs: "precompile-jruby"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "jruby-9.4"
+          bundler-cache: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-jruby-gem
           path: pkg
       - run: ./scripts/test-gem-install
         env:

--- a/README.md
+++ b/README.md
@@ -166,9 +166,16 @@ Argon2id::Password.create("password", salt_len: 0)
 
 ## Requirements
 
-This gem requires the following to run:
+This gem requires any of the following to run:
 
 * [Ruby](https://www.ruby-lang.org/en/) 2.6 to 3.3
+* [JRuby](https://www.jruby.org) 9.4
+* [TruffleRuby](https://www.graalvm.org/ruby/) 24.1
+
+> [!NOTE]
+> The JRuby version of the gem uses
+> [JRuby-OpenSSL](https://github.com/jruby/jruby-openssl)'s implementation of
+> Argon2 instead of the reference C implementation.
 
 ### Native gems
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,13 @@ ENV["RUBY_CC_VERSION"] = %w[3.3.0 3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(":")
 
 gemspec = Gem::Specification.load("argon2id.gemspec")
 
+if RUBY_PLATFORM == "java"
+  gemspec.files.reject! { |path| File.fnmatch?("ext/*", path) }
+  gemspec.extensions.clear
+  gemspec.platform = Gem::Platform.new("java")
+  gemspec.required_ruby_version = ">= 3.1.0"
+end
+
 Gem::PackageTask.new(gemspec).define
 
 Rake::ExtensionTask.new("argon2id", gemspec) do |e|
@@ -49,6 +56,15 @@ namespace :gem do
         bundle exec rake native:#{platform} pkg/#{gemspec.full_name}-#{Gem::Platform.new(platform)}.gem PATH="/usr/local/bin:$PATH"
       SCRIPT
     end
+  end
+
+  desc "Compile gem for JRuby"
+  task :jruby do
+    RakeCompilerDock.sh <<~SCRIPT, rubyvm: "jruby", platform: "jruby", verbose: true
+      gem install bundler --no-document &&
+      bundle &&
+      bundle exec rake gem
+    SCRIPT
   end
 end
 

--- a/ext/argon2id/argon2id.c
+++ b/ext/argon2id/argon2id.c
@@ -70,6 +70,9 @@ rb_argon2id_verify(VALUE module, VALUE encoded, VALUE pwd) {
   if (result == ARGON2_VERIFY_MISMATCH) {
     return Qfalse;
   }
+  if (result == ARGON2_DECODING_FAIL || result == ARGON2_DECODING_LENGTH_FAIL) {
+    rb_raise(rb_eArgError, "%s", argon2_error_message(result));
+  }
 
   rb_raise(cArgon2idError, "%s", argon2_error_message(result));
 }

--- a/lib/argon2id/password.rb
+++ b/lib/argon2id/password.rb
@@ -44,7 +44,7 @@ module Argon2id
       \$
       ([a-zA-Z0-9+/]+)
       \$
-      [a-zA-Z0-9+/]+
+      ([a-zA-Z0-9+/]+)
       \z
     }x.freeze
 
@@ -68,6 +68,9 @@ module Argon2id
 
     # The salt.
     attr_reader :salt
+
+    # The hash output.
+    attr_reader :output
 
     # Create a new Password object that hashes a given plain text password +pwd+.
     #
@@ -101,8 +104,6 @@ module Argon2id
       )
     end
 
-    # call-seq: Argon2id::Password.new(encoded)
-    #
     # Create a new Password with the given encoded password hash.
     #
     #   password = Argon2id::Password.new("$argon2id$v=19$m=19456,t=2,p=1$FI8yp1gXbthJCskBlpKPoQ$nOfCCpS2r+I8GRN71cZND4cskn7YKBNzuHUEO3YpY2s")
@@ -118,6 +119,7 @@ module Argon2id
       @t_cost = Integer($4)
       @parallelism = Integer($5)
       @salt = $6.unpack1("m")
+      @output = $7.unpack1("m")
     end
 
     # Return the encoded password hash.

--- a/test/test_hash_encoded.rb
+++ b/test/test_hash_encoded.rb
@@ -17,42 +17,32 @@ class TestHashEncoded < Minitest::Test
   end
 
   def test_raises_with_too_short_output
-    error = assert_raises(Argon2id::Error) do
+    assert_raises(Argon2id::Error) do
       Argon2id.hash_encoded(2, 256, 1, "password", "somesalt", 1)
     end
-
-    assert_equal "Output is too short", error.message
   end
 
   def test_raises_with_too_few_lanes
-    error = assert_raises(Argon2id::Error) do
+    assert_raises(Argon2id::Error) do
       Argon2id.hash_encoded(2, 256, 0, "password", "somesalt", 32)
     end
-
-    assert_equal "Too few lanes", error.message
   end
 
   def test_raises_with_too_small_memory_cost
-    error = assert_raises(Argon2id::Error) do
+    assert_raises(Argon2id::Error) do
       Argon2id.hash_encoded(2, 0, 1, "password", "somesalt", 32)
     end
-
-    assert_equal "Memory cost is too small", error.message
   end
 
   def test_raises_with_too_small_time_cost
-    error = assert_raises(Argon2id::Error) do
+    assert_raises(Argon2id::Error) do
       Argon2id.hash_encoded(0, 256, 1, "password", "somesalt", 32)
     end
-
-    assert_equal "Time cost is too small", error.message
   end
 
   def test_raises_with_too_short_salt
-    error = assert_raises(Argon2id::Error) do
-      Argon2id.hash_encoded(0, 256, 1, "password", "", 32)
+    assert_raises(Argon2id::Error) do
+      Argon2id.hash_encoded(2, 256, 1, "password", "", 32)
     end
-
-    assert_equal "Salt is too short", error.message
   end
 end

--- a/test/test_verify.rb
+++ b/test/test_verify.rb
@@ -19,7 +19,7 @@ class TestVerify < Minitest::Test
   end
 
   def test_raises_if_given_invalid_encoded
-    assert_raises(Argon2id::Error) do
+    assert_raises(ArgumentError) do
       Argon2id.verify("", "opensesame")
     end
   end


### PR DESCRIPTION
As JRuby doesn't support the C extension, use JRuby-OpenSSL's inclusion of Bouncy Castle to re-implement the libargon2 interface using Argon2BytesGenerator.

In order for the C and Java versions to be consistent, we now raise an ArgumentError for any invalid encoded hashes when verifying though the exact error messages returned will differ based on the underlying library (so those arguably-over-specific assertions have been removed).

In order to implement constant-time verification, we now also extract the output of each encoded password hash.
