### PR TITLE
Use RakeCompilerDock.set_ruby_cc_version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ cross_platforms = %w[
   x86_64-linux-musl
 ].freeze
 
-ENV["RUBY_CC_VERSION"] = "3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10"
+RakeCompilerDock.set_ruby_cc_version("~> 2.6", "~> 3.0")
 
 gemspec = Gem::Specification.load("argon2id.gemspec")
 
@@ -59,6 +59,7 @@ namespace :gem do
     desc "Compile and build native gem for #{platform}"
     task platform do
       RakeCompilerDock.sh <<~SCRIPT, platform: platform, verbose: true
+        rbenv shell 3.1.6 &&
         gem install bundler --no-document &&
         bundle &&
         bundle exec rake native:#{platform} pkg/#{gemspec.full_name}-#{Gem::Platform.new(platform)}.gem PATH="/usr/local/bin:$PATH"

--- a/argon2id.gemspec
+++ b/argon2id.gemspec
@@ -54,6 +54,6 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--main", "README.md"]
 
   s.add_development_dependency("rake-compiler", "~> 1.2")
-  s.add_development_dependency("rake-compiler-dock", "~> 1.8")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.9")
   s.add_development_dependency("minitest", "~> 5.25")
 end

--- a/lib/argon2id/extension.rb
+++ b/lib/argon2id/extension.rb
@@ -10,6 +10,7 @@ if RUBY_PLATFORM == "java"
     class Password
       def self.hash_encoded(t_cost, m_cost, parallelism, pwd, salt, hashlen)
         raise Error, "Salt is too short" if salt.empty?
+        raise Error, "Memory cost is too small" if m_cost < 8
 
         salt_bytes = salt.to_java_bytes
         output = Java::byte[hashlen].new


### PR DESCRIPTION
Note we still use the old rbenv default of Ruby 3.1.6 in the rake-compiler-dock containers.
